### PR TITLE
feat: Allow caching of 404 responses

### DIFF
--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -2,6 +2,8 @@
 /// Can also be used with placeholder and error widgets.
 library cached_network_image;
 
+export 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    show ImageNotFoundException;
 export 'package:flutter_cache_manager/flutter_cache_manager.dart'
     show CacheManagerLogLevel, DownloadProgress;
 

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -3,10 +3,10 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'dart:ui';
 
-import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart' as platform
     show ImageLoader;
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -120,6 +120,11 @@ class ImageLoader implements platform.ImageLoader {
         }
         if (result is FileInfo) {
           final file = result.file;
+
+          if (file == null) {
+            throw ImageNotFoundException(url);
+          }
+
           final bytes = await file.readAsBytes();
           final decoded = await decode(bytes);
           yield decoded;

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -12,11 +12,20 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface: ^4.0.0
-  cached_network_image_web: ^1.1.1
+  cached_network_image_platform_interface:
+    git:
+      url: git@github.com:11wizards/flutter_cached_network_image.git
+      path: cached_network_image_platform_interface
+  cached_network_image_web:
+    git:
+      url: git@github.com:11wizards/flutter_cached_network_image.git
+      path: cached_network_image_web
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.3.1
+  flutter_cache_manager:
+    git:
+      url: git@github.com:11wizards/flutter_cache_manager.git
+      path: flutter_cache_manager
   octo_image: ^2.0.0
 
 dev_dependencies:

--- a/cached_network_image_platform_interface/lib/cached_network_image_platform_interface.dart
+++ b/cached_network_image_platform_interface/lib/cached_network_image_platform_interface.dart
@@ -10,6 +10,12 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 /// Listener for errors
 typedef ErrorListener = void Function(Object);
 
+class ImageNotFoundException implements Exception {
+  final String url;
+
+  const ImageNotFoundException(this.url);
+}
+
 /// Render options for images on the web platform.
 enum ImageRenderMethodForWeb {
   /// HtmlImage uses a default web image including default browser caching.

--- a/cached_network_image_platform_interface/pubspec.yaml
+++ b/cached_network_image_platform_interface/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.3.1
+  flutter_cache_manager:
+    git:
+      url: git@github.com:11wizards/flutter_cache_manager.git
+      path: flutter_cache_manager
 
 dev_dependencies:
   file: '>=6.1.4 <8.0.0'

--- a/cached_network_image_web/lib/cached_network_image_web.dart
+++ b/cached_network_image_web/lib/cached_network_image_web.dart
@@ -7,7 +7,7 @@ import 'dart:ui' as ui;
 
 import 'package:cached_network_image_platform_interface'
         '/cached_network_image_platform_interface.dart' as platform
-    show ImageLoader, ImageRenderMethodForWeb;
+    show ImageLoader, ImageRenderMethodForWeb, ImageNotFoundException;
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 
@@ -132,6 +132,9 @@ class ImageLoader implements platform.ImageLoader {
         }
         if (result is FileInfo) {
           final file = result.file;
+          if (file == null) {
+            throw platform.ImageNotFoundException(url);
+          }
           final bytes = await file.readAsBytes();
           final decoded = await decode(bytes);
           yield decoded;

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -8,10 +8,16 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface: ^4.0.0
+  cached_network_image_platform_interface:
+    git:
+      url: git@github.com:11wizards/flutter_cached_network_image.git
+      path: cached_network_image_platform_interface
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.3.1
+  flutter_cache_manager:
+    git:
+      url: git@github.com:11wizards/flutter_cache_manager.git
+      path: flutter_cache_manager
 
 dev_dependencies:
   file: '>=6.1.4 <8.0.0'


### PR DESCRIPTION
Uses a new version of flutter_cache_manager that supports caching 404 responses. This is handled by throwing the new ImageNotFound exception when both:
  - The response status code is a 404
  - The cache manager is configured to allow caching of 404s

The error builder will be called with this error at which point the user may customise the result of the builder or show some placeholder value.